### PR TITLE
test: Only run tests on push.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   - push
-  - pull_request
 
 jobs:
   test:
@@ -24,10 +23,3 @@ jobs:
         pip install tox tox-gh-actions
     - name: Test with tox
       run: tox
-
-    # Run these ? Check and distcheck
-    # - name: Run check
-    #   run: make check
-
-    # - name: Run distcheck
-    #   run: make distcheck


### PR DESCRIPTION
We were running tests on PR and push in parallel, but push covers our
use-cases for now.
Closes Dedupe Tests in GitHub Workflow #9.